### PR TITLE
Integrate with huggingface

### DIFF
--- a/extract_clip/model.py
+++ b/extract_clip/model.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
-
+from huggingface_hub import PyTorchModelHubMixin
 
 class Bottleneck(nn.Module):
     expansion = 4
@@ -203,7 +203,11 @@ class Transformer(nn.Module):
         return self.resblocks(x)
 
 
-class VisionTransformer(nn.Module):
+class VisionTransformer(nn.Module,
+                        PyTorchModelHubMixin,
+                        library_name ="UniFormerV2",
+                        repo_url = "https://github.com/OpenGVLab/UniFormerV2"
+                        ):
     def __init__(self, input_resolution: int, patch_size: int, width: int, layers: int, heads: int, output_dim: int):
         super().__init__()
         self.input_resolution = input_resolution

--- a/extract_clip/model.py
+++ b/extract_clip/model.py
@@ -244,7 +244,11 @@ class VisionTransformer(nn.Module,
         return x
 
 
-class CLIP(nn.Module):
+class CLIP(nn.Module,
+            PyTorchModelHubMixin,
+            library_name ="UniFormerV2",
+            repo_url = "https://github.com/OpenGVLab/UniFormerV2"
+            ):
     def __init__(self,
                  embed_dim: int,
                  # vision

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         "pillow",
         "sklearn",
         "tensorboard",
-        "timm"
+        "timm",
+        "huggingface_hub>=0.22"
     ],
     extras_require={"tensorboard_video_visualization": ["moviepy"]},
     packages=find_packages(exclude=("configs", "tests")),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ setup(
         "scikit-learn",
         "tensorboard",
         "timm",
-        "huggingface_hub>=0.22"
+        "huggingface_hub>=0.22",
+        "iopath",
+        "fvcore",
+        "pytorchvideo"
     ],
     extras_require={"tensorboard_video_visualization": ["moviepy"]},
     packages=find_packages(exclude=("configs", "tests")),

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "pandas",
         "torchvision>=0.4.2",
         "pillow",
-        "sklearn",
+        "scikit-learn",
         "tensorboard",
         "timm",
         "huggingface_hub>=0.22"

--- a/slowfast/models/uniformer.py
+++ b/slowfast/models/uniformer.py
@@ -8,6 +8,7 @@ from timm.models.vision_transformer import _cfg
 from timm.models.layers import trunc_normal_, DropPath, to_2tuple
 from .build import MODEL_REGISTRY
 import os
+from huggingface_hub import PyTorchModelHubMixin
 
 import slowfast.utils.logging as logging
 
@@ -256,7 +257,11 @@ class PatchEmbed(nn.Module):
 
 
 @MODEL_REGISTRY.register()
-class Uniformer(nn.Module):
+class Uniformer(nn.Module,
+                PyTorchModelHubMixin,
+                library_name ="UniFormerV2",
+                repo_url = "https://github.com/OpenGVLab/UniFormerV2"
+                ):
     """ Vision Transformer
     A PyTorch impl of : `An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale`  -
         https://arxiv.org/abs/2010.11929

--- a/slowfast/models/uniformerv2.py
+++ b/slowfast/models/uniformerv2.py
@@ -2,6 +2,7 @@
 import json
 import torch
 import torch.nn as nn
+from huggingface_hub import PyTorchModelHubMixin
 
 import slowfast.models.uniformerv2_model as model
 from .build import MODEL_REGISTRY
@@ -12,7 +13,11 @@ logger = logging.get_logger(__name__)
 
 
 @MODEL_REGISTRY.register()
-class Uniformerv2(nn.Module):
+class Uniformerv2(nn.Module,
+                PyTorchModelHubMixin,
+                library_name ="UniFormerV2",
+                repo_url = "https://github.com/OpenGVLab/UniFormerV2"
+                ):
     def __init__(self, cfg):
         super().__init__()
 

--- a/slowfast/models/uniformerv2_model.py
+++ b/slowfast/models/uniformerv2_model.py
@@ -8,6 +8,7 @@ from torch import nn
 from torch.nn import MultiheadAttention
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
+from huggingface_hub import PyTorchModelHubMixin
 
 
 import slowfast.utils.logging as logging
@@ -274,7 +275,11 @@ class Transformer(nn.Module):
             return self.proj((1 - weight) * cls_token[0, :, :] + weight * residual)
 
 
-class VisionTransformer(nn.Module):
+class VisionTransformer(nn.Module,
+                        PyTorchModelHubMixin,
+                        library_name ="UniFormerV2",
+                        repo_url = "https://github.com/OpenGVLab/UniFormerV2"
+                        ):
     def __init__(
         self, 
         # backbone


### PR DESCRIPTION
## this pr will mainly add 3 methods to the uniformerv2 models

* `save_pretrained`
* `push_to_hub`
* `from_pretrained` : initialize and load the model weights

allowing your models to be easily integrated with huggingface using the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class, I made this notebook https://colab.research.google.com/drive/1_H5LR5EclcBAhtyrarB_c49-TEceKoZU?usp=sharing  explaining how to use it
by the end of the notebook all users can load your model simply by 
```python
!pip install -q git+https://github.com/not-lain/UniFormerV2.git@integrate-with-huggingface # or your main branch when this is merged
from slowfast.models.uniformerv2_model import VisionTransformer
new_model = VisionTransformer.from_pretrained("not-lain/uniformerv2_b16") 
# no more renitializing the model and manually downloading the weights
```
I also made a huggingface [space](https://huggingface.co/spaces/not-lain/uniformerv2_demo) further showcasing how to use this pr.

## Why you should integrate your model with huggingface ?

* easily save, load and push your model
* Keep track on how many times your model has been downloaded by the community.
* Automatic model card generation: the metadata in the card allows you to filter your [searches](https://huggingface.co/models?other=UniFormerV2) easily to check how many UniFormerV2 models exist on the Hub .
* Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "UniFormerV2" library official on the Hub meaning better discoverability + possibility to add code snippets.

do not hesitate if you have any reviews on the pr or any questions.
 
Kind regards, 
Hafedh Hichri
